### PR TITLE
raised action versions to v1

### DIFF
--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create version releases
-        uses: climpr/semver-release@v0
+        uses: climpr/semver-release@v1
         with:
           update-type: ${{ github.event.inputs.update-type }}
           label: ${{ github.event.inputs.label }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This action is used by calling it in a step as follows:
 
 ```yaml
 - name: Get Bicep Modules
-  uses: climpr/get-bicep-modules@v0
+  uses: climpr/get-bicep-modules@v1
   with:
     root-path: bicep-modules
 ```
@@ -19,7 +19,7 @@ This action is used by calling it in a step as follows:
 
 ```yaml
 - name: Get Bicep Modules
-  uses: climpr/get-bicep-modules@v0
+  uses: climpr/get-bicep-modules@v1
   with:
     root-path: bicep-modules
     module-name: name-of-module
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Get Bicep Modules
         id: get-module-name
-        uses: climpr/get-bicep-modules@v0
+        uses: climpr/get-bicep-modules@v1
         with:
           root-path: bicep-modules
           module-name: ${{ inputs.module-name }}
@@ -82,7 +82,7 @@ jobs:
           subscription-id: ${{ vars.SUBSCRIPTION_ID }}
 
       - name: publish
-        uses: climpr/publish-bicep-module@v0
+        uses: climpr/publish-bicep-module@v1
         with:
           root-path: ${{ env.root-path }}
           module-name: ${{ fromJson(steps.get-module-name.outputs.module-names)[0] }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Get Bicep modules
         id: get-module-names
-        uses: climpr/get-bicep-modules@v0
+        uses: climpr/get-bicep-modules@v1
         with:
           root-path: ${{ env.root-path }}
           module-name: ${{ inputs.module-name }}
@@ -174,7 +174,7 @@ jobs:
           subscription-id: ${{ vars.SUBSCRIPTION_ID }}
 
       - name: Write module documentation
-        uses: climpr/document-bicep-module@v0
+        uses: climpr/document-bicep-module@v1
         with:
           root-path: ${{ env.root-path }}
           module-name: ${{ matrix.module-name }}


### PR DESCRIPTION
internal testing succeeded.
Has a soft dependencies from readme file references to the following modules that must be raised to v1:

publish-bicep-module (not yet tested) https://github.com/climpr/publish-bicep-module/pull/3
document-bicep-module (tested OK) https://github.com/climpr/document-bicep-module/pull/2

EDIT:
testing succeeded for dependencies